### PR TITLE
Externalize the Django configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,21 @@ by Tharathorn Bunrattanasathian
 
 ### How to run the app server for the project 
 1. Make sure you are in the root directory (repository root) of the project
-2. Run ```pip install``` first.
-3. Import the necessary Question data from ```db.sql``` to the SQLite database. You can either use the following database browsers to migrate it:
+2. Create ```settings.ini``` for your local app environment settings *(See default guide below)*
+    - Make sure your secret key is strong enough. (Recommended: ```PBKDF2``` algorithm with a ```SHA256``` hash)
+3. Run ```pip install -r requirements.txt``` first to install required packages for the project.
+4. Import the optional Question data from ```db.sql``` to the SQLite database. You can either use the following database browsers to migrate it:
     - DB Browser for SQLite
     - DBeaver
-4. Run ```python manage.py runserver``` and, Voila!, the server should listen on the default port.
+5. Run ```python manage.py runserver``` and, Voila!, the server should listen on the default port.
 
-
+### .env default guide
+| Config variable | Value | Note |
+|:---:|:---:|:---:|
+|DEBUG|True|If the project are in development mode|
+|LANGUAGE_CODE|en-us|Default language for the project|
+|TIME_ZONE|Asia/Bangkok||
+|DATABASE_URL|sqlite://./db.sqlite3|If your SQLite database file is in the same root directory as the project|
 ### Dependency requirements
 Easily install dependencies by using ```requirements.txt```
 
@@ -17,7 +25,9 @@ Easily install dependencies by using ```requirements.txt```
 |:---:|:---:|
 |Python | 3.7.3 or higher|
 |Django | 2.2.5|
-|Python-decouple | 3.1|
+|Python-decouple | 3.1 |
+|dj-database-url|0.5.0|
+|Unipath|1.1|
 
 ### Progress overview
 |Part #     | Description|Done?|

--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
 by Tharathorn Bunrattanasathian
 
 ### How to run the app server for the project 
-1. Run ```pip install``` first.
-2. Import the necessary Question data from ```db.sql``` to the SQLite database.
-3. Run ```python manage.py runserver``` and, Voila!, the server should listen on the default port.
+1. Make sure you are in the root directory (repository root) of the project
+2. Run ```pip install``` first.
+3. Import the necessary Question data from ```db.sql``` to the SQLite database. You can either use the following database browsers to migrate it:
+    - DB Browser for SQLite
+    - DBeaver
+4. Run ```python manage.py runserver``` and, Voila!, the server should listen on the default port.
 
 
 ### Dependency requirements
@@ -14,6 +17,7 @@ Easily install dependencies by using ```requirements.txt```
 |:---:|:---:|
 |Python | 3.7.3 or higher|
 |Django | 2.2.5|
+|Python-decouple | 3.1|
 
 ### Progress overview
 |Part #     | Description|Done?|

--- a/django_polls/settings.py
+++ b/django_polls/settings.py
@@ -9,21 +9,23 @@ https://docs.djangoproject.com/en/2.2/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/2.2/ref/settings/
 """
-
+from decouple import config
+from unipath import Path
+from dj_database_url import parse as db_url
 import os
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BASE_DIR = Path(__file__).parent #os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = '8kan1sqp*brq6pm+m0luvl_pg3^!1z5y2(nmz671m)^48ho64-'
+SECRET_KEY = config('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = config('DEBUG', default=False, cast=bool)
 
 ALLOWED_HOSTS = ['*']
 
@@ -74,10 +76,15 @@ WSGI_APPLICATION = 'django_polls.wsgi.application'
 # https://docs.djangoproject.com/en/2.2/ref/settings/#databases
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
-    }
+    'default': config(
+        'DATABASE_URL',
+        default='sqlite:///' + BASE_DIR.child('db.sqlite3'),
+        cast=db_url
+    )
+    # {
+    #     'ENGINE': 'django.db.backends.sqlite3',
+    #     'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+    # }
 }
 
 
@@ -103,9 +110,9 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/2.2/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = config('LANGUAGE_CODE', cast=str)
 
-TIME_ZONE = 'Asia/Bangkok'
+TIME_ZONE = config('TIME_ZONE', cast=str)
 
 USE_I18N = True
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Django==2.2.5
+python-decouple==3.1

--- a/settings.ini
+++ b/settings.ini
@@ -1,0 +1,6 @@
+[settings]
+DEBUG=True
+LANGUAGE_CODE=en-us
+TIME_ZONE=Asia/Bangkok
+SECRET_KEY=8kan1sqp*brq6pm+m0luvl_pg3^!1z5y2(nmz671m)^48ho64-
+DATABASE_URL=sqlite://./db.sqlite3


### PR DESCRIPTION
We externalize the Django configuration to decouple the configuration which is based on one's development environment from the code. Please review.

The following configurations have been altered and externalized:

- ```DEBUG```
- ```LANGUAGE_CODE```
- ```TIME_ZONE```
- ```SECRET_KEY```
- ```DATABASE_URL```